### PR TITLE
Fix for "getpeerinfo" implementation

### DIFF
--- a/src/Network/Bitcoin/Net.hs
+++ b/src/Network/Bitcoin/Net.hs
@@ -21,17 +21,16 @@ import Network.Bitcoin.Internal
 getConnectionCount :: Auth -> IO Integer
 getConnectionCount auth = callApi auth "getconnectioncount" []
 
--- | Information on a given connected node in the network.
+-- | Information about a peer node of the Bitcoin network.
 --
 --   The documentation for this data structure is incomplete, as I honestly
 --   don't know what some of these fields are for. Patches are welcome!
 data PeerInfo =
-    PeerInfo { -- | The ip:port of this peer, as a string.
+    PeerInfo { -- | The IP:port of this peer, as a string.
                addressName :: Text
              , services :: Text
-             -- | Relative to when we first time we conected with this peer
-             --   (and in milliseconds), the last time we sent this peer any
-             --   data.
+             -- | Relative to the first time we conected with this peer (and in
+             -- milliseconds), the last time we sent this peer any data.
              , lastSend :: Integer
              -- | Relative to the first time we connected with this peer
              --   (and in milliseconds), the last time we sent this peer any
@@ -40,10 +39,10 @@ data PeerInfo =
               -- | How long have we been connected to this peer (in
               --   milliseconds).
              , connectionTime :: Integer
-             -- | The version of bitcoind the peer is running.
+             -- | The version of the Bitcion client the peer is running.
              , peerVersion :: Integer
-             -- | The sub-version of bitcoind the peer is running.
-             , peerSubversion :: Integer
+             -- | The sub-version of the Bitcoin client the peer is running.
+             , peerSubversion :: Text
              , inbound :: Bool
              , releaseTime :: Integer
              , startingHeight :: Integer
@@ -66,6 +65,6 @@ instance FromJSON PeerInfo where
                                     <*> o .: "banscore"
     parseJSON _ = mzero
 
--- | Returns data about each connected network node.
-getPeerInfo :: Auth -> IO PeerInfo
+-- | Returns data about all connected peer nodes.
+getPeerInfo :: Auth -> IO [PeerInfo]
 getPeerInfo auth = callApi auth "getpeerinfo" []


### PR DESCRIPTION
Clark,

I've put together a small patch that fixes the implementation of the "getpeerinfo" API call. The types were wrong in a couple of places, so parsing the JSON data would fail and you'd get a `BitcoinResultTypeError` every time.

Note that I'm using Bitcoin-Qt (v0.8.1-beta) rather than bitcoind. I assume the two clients share the same API, but I haven't been able to install bitcoind to confirm.

I've been playing around with information extracted from the blockchain, rather than creating transactions, so I might get into other parts of the API you haven't looked at closely. This is my first time using GitHub, but I'd like to get involved, so do let me know if you're looking for specific contributions.

Regards,

Eric
