### PR TITLE
Fixed `getinfo` implementation

### DIFF
--- a/src/Network/Bitcoin/Wallet.hs
+++ b/src/Network/Bitcoin/Wallet.hs
@@ -108,7 +108,7 @@ instance FromJSON BitcoindInfo where
                                         <*> o .:  "proxy"
                                         <*> o .:  "difficulty"
                                         <*> o .:  "testnet"
-                                        <*> o .:  "keypoololddest"
+                                        <*> o .:  "keypoololdest"
                                         <*> o .:  "keypoolsize"
                                         <*> o .:  "paytxfee"
                                         <*> o .:? "unlocked_until"


### PR DESCRIPTION
One more small fix.

--- Commit message: -------------------------------------------------------------------------------

There was a typo in the name of a JSON field referenced in the `FromJSON`
implementation of `BitcoindInfo`. Because the field was required, all
calls to `getBitcoinInfo` threw exceptions.
