### PR TITLE
Removed dependency on old version of Aeson

### DIFF
--- a/network-bitcoin.cabal
+++ b/network-bitcoin.cabal
@@ -49,7 +49,7 @@ Library
     Network.Bitcoin.Wallet
 
   Build-depends:
-    aeson >= 0.6.1,
+    aeson >= 0.6.1 && < 0.7.1,
     bytestring >= 0.9 && < 0.11,
     attoparsec == 0.10.*,
     unordered-containers >= 0.2,
@@ -68,7 +68,7 @@ Executable network-bitcoin-tests
   ghc-options: -Wall
   main-is: Test/Main.hs
   build-depends:
-    aeson >= 0.6.1,
+    aeson >= 0.6.1 && < 0.7.1,
     bytestring >= 0.9 && < 0.11,
     attoparsec == 0.10.*,
     unordered-containers >= 0.2,


### PR DESCRIPTION
Everything builds fine with 0.7.0.1 so I removed the ceiling but it may be better to just increase it.

closes #12 
does this close #10 as well? Scientific is included in 0.7. In that case, it may be better to increase the dependency floor as well.
