### PR TITLE
Support for listsinceblock

### DIFF
--- a/src/Network/Bitcoin.hs
+++ b/src/Network/Bitcoin.hs
@@ -100,6 +100,7 @@ module Network.Bitcoin
     -- , listAccounts
     , SinceBlock(..)
     , SinceBlockTransaction(..)
+    , TransactionCategory(..)
     , listSinceBlock
     -- , getTransaction
     , backupWallet

--- a/src/Network/Bitcoin/Wallet.hs
+++ b/src/Network/Bitcoin/Wallet.hs
@@ -45,6 +45,7 @@ module Network.Bitcoin.Wallet ( Auth(..)
                               -- , listAccounts
                               , SinceBlock(..)
                               , SinceBlockTransaction(..)
+                              , TransactionCategory(..)
                               , listSinceBlock
                               -- , getTransaction
                               , backupWallet
@@ -421,11 +422,11 @@ instance FromJSON SinceBlock where
 data SinceBlockTransaction =
     SinceBlockTransaction {
         -- | The account associated with the receiving address.
-        sbtReceivingAccount :: Account
+          sbtReceivingAccount :: Account
         -- | The receiving address of the transaction.
         , sbtAddress :: Address
         -- | The category of the transaction (As of 0.8.6 this field can be send,orphan,immature,generate,receive,move).
-        , sbtCategory :: Text
+        , sbtCategory :: TransactionCategory
         -- | The amount of bitcoins transferred.
         , sbtAmountBitcoin :: BTC
         -- | The number of confirmation of the transaction.
@@ -455,6 +456,27 @@ instance FromJSON SinceBlockTransaction where
                                                  <*> o .:  "walletconflicts"
                                                  <*> o .:  "time"
                                                  <*> o .:  "timereceived"
+    parseJSON _ = mzero
+    
+data TransactionCategory = TCSend
+                         | TCOrphan
+                         | TCImmature
+                         | TCGenerate
+                         | TCReceive
+                         | TCMove
+                         | TCErrorUnexpected Text
+    deriving ( Show, Read, Ord, Eq )
+
+instance FromJSON TransactionCategory where
+    parseJSON (String s) = return $ createTC s
+        where createTC :: Text -> TransactionCategory
+              createTC "send"     = TCSend
+              createTC "orphan"   = TCOrphan
+              createTC "immature" = TCImmature
+              createTC "generate" = TCGenerate
+              createTC "receive"  = TCReceive
+              createTC "move"     = TCMove
+              createTC uc         = TCErrorUnexpected uc
     parseJSON _ = mzero
 
 listSinceBlock :: Auth


### PR DESCRIPTION
This adds the method `listsinceblock`. I could not reproduce the transaction malleability bug, but I don't think `walletconflicts` is going to be a problem.

I tested it in `ghci` using the following snippet :

```
Prelude Network.Bitcoin> import Data.Text
Prelude Data.Text Network.Bitcoin> let auth = Auth (pack "...") (pack "...") (pack "...")
Prelude Data.Text Network.Bitcoin> :set +m
Prelude Data.Text Network.Bitcoin> let lsb = do
Prelude Data.Text Network.Bitcoin|      bh <- getBlockHash auth 226000
Prelude Data.Text Network.Bitcoin|      stuff <- listSinceBlock auth bh Nothing
Prelude Data.Text Network.Bitcoin|      print stuff
Prelude Data.Text Network.Bitcoin| 
Prelude Data.Text Network.Bitcoin> lsb
SinceBlock {transactions = fromList [SinceBlockTransaction {sbtReceivingAccount = "Some account", sbtAddress = "Some address", sbtCategory = "receive", sbtAmountBitcoin = 1.80000000, sbtConfirmations = 131, sbtBlockHash = "Some hash", sbtBlockIndex = 1, sbtBlockTime = 1.39e9, sbtTransactionId = "Some txid", sbtWalletConflicts = fromList [], sbtTime = 1398999999, sbtTimeReceived = 1398999999}], lastBlockHash = "Some hash"}
```
