### PR TITLE
modify API to reuse HTTP connections via Manager

### DIFF
--- a/network-bitcoin.cabal
+++ b/network-bitcoin.cabal
@@ -1,5 +1,5 @@
 Name:                network-bitcoin
-Version:             1.6.0
+Version:             1.7.0
 Synopsis:            An interface to bitcoind.
 Description:
     This can be used to send Bitcoins, query balances, etc.  It
@@ -49,16 +49,19 @@ Library
     Network.Bitcoin.Wallet
 
   Build-depends:
-    aeson >= 0.6.1 && < 0.7.1,
+    aeson >= 0.8,
     bytestring >= 0.9 && < 0.11,
-    attoparsec == 0.10.*,
+    cookie >= 0.4,
+    attoparsec == 0.12.*,
     unordered-containers >= 0.2,
     HTTP >= 4000,
+    http-types >= 0.8.5,
     network >= 2.3,
     text >= 0.11,
     vector >= 0.10,
     base == 4.*,
-    time >= 1.4.2
+    time >= 1.4.2,
+    http-client >= 0.4.6
 
 Source-repository head
   type: git
@@ -69,16 +72,18 @@ Executable network-bitcoin-tests
   ghc-options: -Wall
   main-is: Test/Main.hs
   build-depends:
-    aeson >= 0.6.1 && < 0.7.1,
+    aeson >= 0.8,
     bytestring >= 0.9 && < 0.11,
-    attoparsec == 0.10.*,
+    cookie >= 0.4,
+    attoparsec == 0.12.*,
     unordered-containers >= 0.2,
     HTTP >= 4000,
+    http-types >= 0.8.5,
     network >= 2.3,
     text >= 0.11,
     vector >= 0.10,
     base == 4.*,
     time >= 1.4.2,
     QuickCheck >= 2.6,
+    http-client >= 0.4.6,
     network-bitcoin
-

--- a/src/Network/Bitcoin.hs
+++ b/src/Network/Bitcoin.hs
@@ -3,7 +3,8 @@
 module Network.Bitcoin
     (
     -- * Common Types
-      Auth(..)
+      Client
+    , getClient
     , BitcoinException(..)
     , HexString
     , TransactionID

--- a/src/Network/Bitcoin/BlockChain.hs
+++ b/src/Network/Bitcoin/BlockChain.hs
@@ -6,7 +6,7 @@
 --
 --   If any APIs are missing, patches are always welcome. If you look at the
 --   source of this module, you'll see that the interface code is trivial.
-module Network.Bitcoin.BlockChain ( Auth(..)
+module Network.Bitcoin.BlockChain ( Client
                                   , TransactionID
                                   , BTC
                                   , getBlockCount
@@ -30,34 +30,34 @@ import Network.Bitcoin.Internal
 import Network.Bitcoin.RawTransaction
 
 -- | Returns the number of blocks in the longest block chain.
-getBlockCount :: Auth -> IO Integer
-getBlockCount auth = callApi auth "getblockcount" []
+getBlockCount :: Client -> IO Integer
+getBlockCount client = callApi client "getblockcount" []
 
 -- | Returns the proof-of-work difficulty as a multiple of the minimum
 --   difficulty.
-getDifficulty :: Auth -> IO Integer
-getDifficulty auth = callApi auth "getdifficulty" []
+getDifficulty :: Client -> IO Integer
+getDifficulty client = callApi client "getdifficulty" []
 
 -- | Sets the transaction fee will will pay to the network. Values of 0 are
 --   rejected.
-setTransactionFee :: Auth -> BTC -> IO ()
-setTransactionFee auth fee =
-    stupidAPI <$> callApi auth "settxfee" [ tj fee ]
+setTransactionFee :: Client -> BTC -> IO ()
+setTransactionFee client fee =
+    stupidAPI <$> callApi client "settxfee" [ tj fee ]
         where stupidAPI :: Bool -> ()
               stupidAPI = const ()
 
 -- | Returns all transaction identifiers in the memory pool.
-getRawMemoryPool :: Auth -> IO (Vector TransactionID)
-getRawMemoryPool auth = callApi auth "getrawmempool" []
+getRawMemoryPool :: Client -> IO (Vector TransactionID)
+getRawMemoryPool client = callApi client "getrawmempool" []
 
 -- | The hash of a given block.
 type BlockHash = HexString
 
 -- | Returns the hash of the block in best-block-chain at the given index.
-getBlockHash :: Auth
+getBlockHash :: Client
              -> Integer -- ^ Block index.
              -> IO BlockHash
-getBlockHash auth idx = callApi auth "getblockhash" [ tj idx ]
+getBlockHash client idx = callApi client "getblockhash" [ tj idx ]
 
 -- | Information about a given block in the block chain.
 data Block = Block { blockHash :: BlockHash
@@ -105,8 +105,8 @@ instance FromJSON Block where
     parseJSON _ = mzero
 
 -- | Returns details of a block with given block-hash.
-getBlock :: Auth -> BlockHash -> IO Block
-getBlock auth bh = callApi auth "getblock" [ tj bh ]
+getBlock :: Client -> BlockHash -> IO Block
+getBlock client bh = callApi client "getblock" [ tj bh ]
 
 -- | Information on the unspent transaction in the output set.
 data OutputSetInfo =
@@ -128,8 +128,8 @@ instance FromJSON OutputSetInfo where
     parseJSON _ = mzero
 
 -- | Returns statistics about the unspent transaction output set.
-getOutputSetInfo :: Auth -> IO OutputSetInfo
-getOutputSetInfo auth = callApi auth "gettxoutsetinfo" []
+getOutputSetInfo :: Client -> IO OutputSetInfo
+getOutputSetInfo client = callApi client "gettxoutsetinfo" []
 
 -- | Details about an unspent transaction output.
 data OutputInfo =
@@ -157,8 +157,8 @@ instance FromJSON OutputInfo where
     parseJSON _ = mzero
 
 -- | Returns details about an unspent transaction output.
-getOutputInfo :: Auth
+getOutputInfo :: Client
               -> TransactionID
               -> Integer -- ^ The index we're looking at.
               -> IO OutputInfo
-getOutputInfo auth txid n = callApi auth "gettxout" [ tj txid, tj n ]
+getOutputInfo client txid n = callApi client "gettxout" [ tj txid, tj n ]

--- a/src/Network/Bitcoin/Dump.hs
+++ b/src/Network/Bitcoin/Dump.hs
@@ -17,18 +17,18 @@ import Network.Bitcoin.Internal
 type PrivateKey = Text
 
 -- | Adds a private key (as returned by dumpprivkey) to your wallet.
-importPrivateKey :: Auth
+importPrivateKey :: Client
                  -> PrivateKey
                  -> Maybe Account
                  -- ^ An optional label for the key.
                  -> IO ()
-importPrivateKey auth pk Nothing =
-    unNil <$> callApi auth "importprivkey" [ tj pk ]
-importPrivateKey auth pk (Just label) =
-    unNil <$> callApi auth "importprivkey" [ tj pk, tj label ]
+importPrivateKey client pk Nothing =
+    unNil <$> callApi client "importprivkey" [ tj pk ]
+importPrivateKey client pk (Just label) =
+    unNil <$> callApi client "importprivkey" [ tj pk, tj label ]
 
 -- | Reveals the private key corresponding to the given address.
-dumpPrivateKey :: Auth
+dumpPrivateKey :: Client
                -> Address
                -> IO PrivateKey
-dumpPrivateKey auth addr = callApi auth "dumpprivkey" [ tj addr ]
+dumpPrivateKey client addr = callApi client "dumpprivkey" [ tj addr ]

--- a/src/Network/Bitcoin/Net.hs
+++ b/src/Network/Bitcoin/Net.hs
@@ -6,7 +6,8 @@
 --
 --   If any APIs are missing, patches are always welcome. If you look at the
 --   source of this module, you'll see that the interface code is trivial.
-module Network.Bitcoin.Net ( Auth(..)
+module Network.Bitcoin.Net ( Client
+                           , getClient
                            , getConnectionCount
                            , PeerInfo(..)
                            , getPeerInfo
@@ -18,8 +19,8 @@ import Data.Aeson
 import Network.Bitcoin.Internal
 
 -- | Returns the number of connections to other nodes.
-getConnectionCount :: Auth -> IO Integer
-getConnectionCount auth = callApi auth "getconnectioncount" []
+getConnectionCount :: Client -> IO Integer
+getConnectionCount client = callApi client "getconnectioncount" []
 
 -- | Information about a peer node of the Bitcoin network.
 --
@@ -68,5 +69,5 @@ instance FromJSON PeerInfo where
     parseJSON _ = mzero
 
 -- | Returns data about all connected peer nodes.
-getPeerInfo :: Auth -> IO [PeerInfo]
-getPeerInfo auth = callApi auth "getpeerinfo" []
+getPeerInfo :: Client -> IO [PeerInfo]
+getPeerInfo client = callApi client "getpeerinfo" []

--- a/src/Network/Bitcoin/Types.hs
+++ b/src/Network/Bitcoin/Types.hs
@@ -2,7 +2,7 @@
 {-# OPTIONS_GHC -Wall #-}
 -- | Contains the common types used through bitcoin RPC calls, that aren't
 --   specific to a single submodule.
-module Network.Bitcoin.Types ( Auth(..)
+module Network.Bitcoin.Types ( Client
                              , BitcoinException(..)
                              , HexString
                              , TransactionID
@@ -18,14 +18,9 @@ import Data.Text ( Text )
 import Data.Typeable
 import qualified Data.ByteString.Lazy as BL
 
--- | 'Auth' describes authentication credentials for
+-- | 'Client' describes authentication credentials and host info for
 -- making API requests to the Bitcoin daemon.
-data Auth = Auth
-    { rpcUrl      :: Text -- ^ URL, with port, where bitcoind listens
-    , rpcUser     :: Text -- ^ same as bitcoind's 'rpcuser' config
-    , rpcPassword :: Text -- ^ same as bitcoind's 'rpcpassword' config
-    }
-    deriving ( Show, Read, Ord, Eq )
+type Client = BL.ByteString -> IO BL.ByteString
 
 -- | A 'BitcoinException' is thrown when 'callApi encounters an
 --   error.  The API error code is represented as an @Int@, the message as

--- a/src/Test/Main.hs
+++ b/src/Test/Main.hs
@@ -23,13 +23,13 @@ qcOnce = quickCheckWith stdArgs { maxSuccess = 1
                                 }
 
 
-auth :: Auth
-auth = Auth "http://localhost:18332" "bitcoinrpc" "bitcoinrpcpassword"
+client :: IO Client
+client = getClient "http://127.0.0.1:18332" "bitcoinrpc" "bitcoinrpcpassword"
 
 
 canGetInfo :: Property
 canGetInfo = monadicIO $ do
-    info <- run $ getBitcoindInfo auth
+    info <- run $ getBitcoindInfo =<< client
     let checks = [ bitcoinVersion info > 80000
                  , onTestNetwork info
                  , bitcoindErrors info == ""
@@ -39,12 +39,12 @@ canGetInfo = monadicIO $ do
 
 canListUnspent :: Property
 canListUnspent = monadicIO $ do
-    _ <- run $ listUnspent auth Nothing Nothing Data.Vector.empty
+    _ <- run $ (\c -> listUnspent c Nothing Nothing Data.Vector.empty) =<< client
     assert True
 
 
 canGetOutputInfo :: Property
 canGetOutputInfo = monadicIO $ do
-    info <- run $ getOutputInfo auth "ab8e26fd95fa371ac15b43684d0c6797fb573757095e7d763ba86ad315f7db04" 1
+    info <- run $ (\c-> getOutputInfo c "ab8e26fd95fa371ac15b43684d0c6797fb573757095e7d763ba86ad315f7db04" 1) =<< client
     _ <- run $ print info
     assert True


### PR DESCRIPTION
The one-connection-per-call design of this library leads to call failures, by way of TCP port exhaustion, when you make a continuous sequence of calls. I replaced Auth and callApi' with getClient, which lets the caller roll the url, credentials, and connection manager into a closure that can be used to make requests. I tested this scanning through the blockchain making ~1M calls without issue. 