### PR TITLE
Fix boolean parsing in signrawtransaction response

### DIFF
--- a/src/Network/Bitcoin/RawTransaction.hs
+++ b/src/Network/Bitcoin/RawTransaction.hs
@@ -342,10 +342,9 @@ data RawSignedTransaction =
                          , hasCompleteSigSet :: Bool
                          }
 
--- I have no idea why they use a 1/0 to represent a boolean.
 instance FromJSON RawSignedTransaction where
     parseJSON (Object o) = RawSignedTransaction <$> o .: "hex"
-                                                <*> (toEnum <$> o .: "complete")
+                                                <*> o .: "complete"
     parseJSON _ = mzero
 
 -- | Sign inputs for a raw transaction.


### PR DESCRIPTION
I'm using Bitcoin-Qt v0.9.3 and `signrawtransaction` returns an actual boolean (like  `{"hex": "whatever", "complete": true}`) instead of 1/0. In the source ( https://github.com/bitcoin/bitcoin/blob/master/src/rpcrawtransaction.cpp#L710 ) it seems like `complete` is a bool, although I can't find any past code that treated it as 1/0.

edit: confirmed on #bitcoin-dev that the docs are just wrong; I also have a pr to bitcoin to fix the docs around this (https://github.com/bitcoin/bitcoin/pull/5773)