### PR TITLE
Fixed changePassword

### DIFF
--- a/src/Network/Bitcoin/Wallet.hs
+++ b/src/Network/Bitcoin/Wallet.hs
@@ -697,7 +697,7 @@ changePassword :: Client
                -- ^ The new password.
                -> IO ()
 changePassword client old new =
-    unNil <$> callApi client "walletpassphrase" [ tj old, tj new ]
+    unNil <$> callApi client "walletpassphrasechange" [ tj old, tj new ]
 
 -- | Removes the wallet encryption key from memory, locking the wallet.
 --


### PR DESCRIPTION
changePassword called "walletpassphrase" just like unlockWallet,
when instead it should call "walletpassphrasechange" according to
https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list