### PR TITLE
Fixed setGenerate in regtest mode

### DIFF
--- a/src/Network/Bitcoin/Internal.hs
+++ b/src/Network/Bitcoin/Internal.hs
@@ -17,6 +17,7 @@ module Network.Bitcoin.Internal ( module Network.Bitcoin.Types
                                 , callApi
                                 , getClient
                                 , Nil(..)
+                                , NilOrArray(..)
                                 , tj
                                 , tjm
                                 , tja
@@ -122,6 +123,13 @@ instance FromJSON Nil where
     parseJSON Null = return $ Nil ()
     parseJSON x    = fail $ "\"null\" was expected, but " ++ show x ++ " was recieved."
 
+-- | Used to parse "null" or [HexString]
+data NilOrArray = NilOrArray {unArr :: Maybe [HexString]}
+
+instance FromJSON NilOrArray where
+    parseJSON Null = return $ NilOrArray Nothing
+    parseJSON a@(Array _) = liftM NilOrArray $ parseJSON a
+    parseJSON x = fail $ "Expected \"null\" or array, but " ++ show x ++ " was recieved."
 
 -- | A handy shortcut for toJSON, because I'm lazy.
 tj :: ToJSON a => a -> Value

--- a/src/Network/Bitcoin/Mining.hs
+++ b/src/Network/Bitcoin/Mining.hs
@@ -40,17 +40,21 @@ getGenerate :: Client -- ^ bitcoind RPC client
 getGenerate client = callApi client "getgenerate" []
 
 -- | Controls whether or not bitcoind is generating bitcoins.
+--   If bitcoind runs in regtest mode the number of generated hashes is returned.
+--   See https://bitcoin.org/en/developer-reference#setgenerate for more details.
 setGenerate :: Client -- ^ bitcoind RPC client
             -> Bool -- ^ Turn it on, or turn it off?
             -> Maybe Int -- ^ Generation is limited to this number of
                          --   processors. Set it to Nothing to keep the value
                          --   at what it was before, Just -1 to use all
                          --   available cores, and any other value to limit it.
-            -> IO ()
+                         --   If bitcoind runs in regtest mode instead of the number of processors,
+                         --   this specifies the number of hashes to generate.
+            -> IO (Maybe [HexString])
 setGenerate client onOff Nothing =
-    unNil <$> callApi client "setgenerate" [ tj onOff ]
+    unArr <$> callApi client "setgenerate" [ tj onOff ]
 setGenerate client onOff (Just limit) =
-    unNil <$> callApi client "setgenerate" [ tj onOff, tj limit ]
+    unArr <$> callApi client "setgenerate" [ tj onOff, tj limit ]
 
 -- | Returns a recent hashes per second performance measurement while
 --   generating.


### PR DESCRIPTION
When calling setGenerate while running bitcoind in regtest mode,
setGenerate is supposed to parse a [HexString] rather than Nil in some cases.
In regtest mode the setgenerate API call doesn't take a number of processors,
but rather a number of hashes to generate, and than proceeds to return these hashes.
A more detailed description of the setgenerate call can be found at [bitcoin.org](https://bitcoin.org/en/developer-reference#setgenerate).
I came across this when playing with a local bitcoind [setup](https://gist.github.com/runjak/ef04bc57e10cb184f919).