### PR TITLE
Bugfix in sendMany

### DIFF
--- a/src/Network/Bitcoin/Wallet.hs
+++ b/src/Network/Bitcoin/Wallet.hs
@@ -334,7 +334,7 @@ sendMany :: Client
          -- ^ An optional transaction comment.
          -> IO TransactionID
 sendMany client acc amounts comm =
-    callApi client "sendmany" [ tj acc, tj $ AA amounts, tj comm ]
+    callApi client "sendmany" [ tj acc, tj $ AA amounts, tj (1 :: Int), tj comm ]
 
 -- TODO: createmultisig.
 --


### PR DESCRIPTION
According to [1](https://bitcoin.org/en/developer-reference#sendmany), sendMany expects a number of minimum confirmations as its third parameter.
With null or the comment given as third parameter, as before,
bitcoind complained in regtest mode and didn't process the request as expected.
I've set the minimum confirmations option to 1, which is the default.
