### PR TITLE
Fixes bug where decodeRawTransaction always failed

### DIFF
--- a/src/Network/Bitcoin/RawTransaction.hs
+++ b/src/Network/Bitcoin/RawTransaction.hs
@@ -289,6 +289,7 @@ data DecodedRawTransaction =
                           -- | The vector of transactions out.
                           , decVout :: Vector TxOut
                           }
+    deriving (Show, Eq)
 
 instance FromJSON DecodedRawTransaction where
     parseJSON (Object o) = DecodedRawTransaction <$> o .: "hex"

--- a/src/Network/Bitcoin/RawTransaction.hs
+++ b/src/Network/Bitcoin/RawTransaction.hs
@@ -292,7 +292,7 @@ data DecodedRawTransaction =
     deriving (Show, Eq)
 
 instance FromJSON DecodedRawTransaction where
-    parseJSON (Object o) = DecodedRawTransaction <$> o .: "hex"
+    parseJSON (Object o) = DecodedRawTransaction <$> o .:? "hex" .!= ""
                                                  <*> o .: "version"
                                                  <*> o .: "locktime"
                                                  <*> o .: "vin"
@@ -301,7 +301,9 @@ instance FromJSON DecodedRawTransaction where
 
 -- | Decodes a raw transaction into a more accessible data structure.
 decodeRawTransaction :: Client -> RawTransaction -> IO DecodedRawTransaction
-decodeRawTransaction client tx = callApi client "decoderawtransaction" [ tj tx ]
+decodeRawTransaction client tx = do
+  res <- callApi client "decoderawtransaction" [ tj tx ]
+  return res { decRaw = tx }
 
 -- | Used internally to give a new 'ToJSON' instance for 'UnspentTransaction'.
 newtype UnspentForSigning = UFS UnspentTransaction

--- a/src/Network/Bitcoin/RawTransaction.hs
+++ b/src/Network/Bitcoin/RawTransaction.hs
@@ -344,6 +344,7 @@ data RawSignedTransaction =
     RawSignedTransaction { rawSigned :: HexString
                          , hasCompleteSigSet :: Bool
                          }
+    deriving (Show, Eq)
 
 instance FromJSON RawSignedTransaction where
     parseJSON (Object o) = RawSignedTransaction <$> o .: "hex"


### PR DESCRIPTION
Bitcoin's rpc command `decoderawtransaction` hasn't sent a `hex` field for a very long time; as far as my code archaeology allowed, I wasn't able to find any `hex` output field for decoderawtransaction since at least version 0.7: https://github.com/bitcoin/bitcoin/blob/0.7.2/src/rpcrawtransaction.cpp#L47

This pull request makes the parsing of the `hex` field optional, and hard-codes the storage of the raw transaction in this field. I would personally opt for removing the decRaw field entirely, since I cannot see it being used at all (since the parsing must have been failing at least since bitcoin 0.7).
